### PR TITLE
Reorder railtie method declaration to avoid.

### DIFF
--- a/lib/heroku-deflater/railtie.rb
+++ b/lib/heroku-deflater/railtie.rb
@@ -12,15 +12,15 @@ module HerokuDeflater
         app.paths['public'].first, app.config.assets.prefix, self.class.cache_control_manager(app)
     end
 
+    def self.cache_control_manager(app)
+      @_cache_control_manager ||= CacheControlManager.new(app)
+    end
+
     # Set default Cache-Control headers to 24 hours.
     # The configuration block in config/application.rb overrides this.
     config.before_initialize do |app|
       cache_control = cache_control_manager(app)
       cache_control.setup_max_age(86400)
-    end
-
-    def self.cache_control_manager(app)
-      @_cache_control_manager ||= CacheControlManager.new(app)
     end
   end
 end


### PR DESCRIPTION
Fixes #28

This avoids an exception when loading the gem;

gems/railties-5.2.3/lib/rails/railtie.rb:192:in `method_missing': undefined method `cache_control_manager' for HerokuDeflater::Railtie:Class (NoMethodError)

In my particular case, this caused no problems on production, but when setting up [Sorbet](https://sorbet.org/) (which loads all code), this exception was raised.